### PR TITLE
Now reading the .nwk file correctly. Also changed version number.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>Context</groupId>
     <artifactId>Context</artifactId>
     <packaging>jar</packaging>
-    <version>0.3</version>
+    <version>0.4</version>
 
     <build>
         <plugins>

--- a/src/main/java/core/graph/PhylogeneticTree.java
+++ b/src/main/java/core/graph/PhylogeneticTree.java
@@ -47,8 +47,8 @@ public class PhylogeneticTree {
      */
     @SuppressFBWarnings({"I18N", "NP_DEREFERENCE_OF_READLINE_VALUE"})
     public Tree getTreeFromFile() throws IOException {
-        File f = new File("src/main/resources/340tree.rooted.TKK.nwk");
-        BufferedReader r = new BufferedReader(new FileReader(f));
+        InputStream stream = this.getClass().getResourceAsStream("/340tree.rooted.TKK.nwk");
+        BufferedReader r = new BufferedReader(new InputStreamReader(stream));
         TreeParser tp = new TreeParser(r);
 
         return tp.tokenize("340tree.rooted.TKK");


### PR DESCRIPTION
This should fix that the phylogenetic tree is causing nullpointers in the executable jar file.
